### PR TITLE
redirect stdout and stderr for tasks to os standard output

### DIFF
--- a/crontainer/task.go
+++ b/crontainer/task.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"math/rand"
 	"os/exec"
+	"os"
 )
 
 type Task struct {
@@ -28,14 +29,14 @@ func (t *Task) Run() {
 	t.log("Started")
 	cmd := exec.Command("/bin/sh", "-c", t.Command)
 
-	out, err := cmd.Output()
+    // TODO Provide an io.Writer as Stdout and Stderr to capture the whole output
+    cmd.Stdin  = os.Stdin
+    cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
 	if err != nil {
 		t.log(err)
 	}
-
-	// TODO Provide an io.Writer as Stdout and Stderr to capture the whole output
-	// The following line only returns the last line of the output
-	t.log(string(out))
 
 	t.log("Done")
 }


### PR DESCRIPTION
Hey @neckhair how would you like to capture the output of a command? This PR simply redirects the output to os.Stdout and os.Stderr but it looks like we're constrained by the Job interface in the cron package if we want to return a buffer with stdout and stderr output along with a standard error if the command fails. 

One solution to this would be to abstract the Job to send a message to a channel where a listener picks up that message and runs the command. Did you have anything in particular in mind for what you might want to do with the output stream? #9 