### PR TITLE
Use staged docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM alpine:3.5
+FROM golang:1.9.1 as builder
+
+COPY /cmd /go/cmd
+COPY /crontainer /go/crontainer
+COPY main.go /go/main.go
+
+# go get triggers a go install that errors, but the required libs are still installed
+# cgo parameters here are for building a statically linked binary
+RUN cd /go && go get; CGO_ENABLED=0 GOOS=linux  go build -a -ldflags '-extldflags "-static"' -o /crontainer .
+
+FROM alpine:3.6
 
 ARG GCRON_VERSION=0.2.0
 
 COPY examples/no_jobs.yml /etc/crontainer.yml
+COPY --from=builder /crontainer /usr/local/bin/crontainer
 
-RUN    apk add --no-cache --update curl \
-    && curl -L -o /usr/local/bin/crontainer "https://github.com/neckhair/crontainer/releases/download/${GCRON_VERSION}/crontainer-linux-386" \
-    && chmod +x /usr/local/bin/crontainer
+RUN apk add --no-cache --update curl && \
+    chmod +x /usr/local/bin/crontainer
 
 ENTRYPOINT ["crontainer"]
 CMD ["--config", "/etc/gcron.yml"]

--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ tasks:
 
 ## Docker
 
+Building the docker image is as simple as:
+
+    docker build -t crontainer .
+
 The tool is built to run inside a Docker container. This is how you use it:
 
-    docker run neckhair/crontainer --command="echo 'Hello World'" --schedule="*/5 * * * * *"
+    docker run crontainer --command="echo 'Hello World'" --schedule="*/5 * * * * *"
 
 Or you can map the configfile in:
 


### PR DESCRIPTION
This changes the Dockerfile to use a [multi-stage build pattern](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) to build a statically linked binary that gets added to an alpine binary.

This also bumps the alpine image to 3.6