### PR TITLE
w.i.p changes for atomic install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 release
 vendor
 crontainer-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM alpine:3.7
+FROM frolvlad/alpine-glibc:alpine-3.7
 
 LABEL maintainer="phil@neckhair.ch"
+LABEL INSTALL="docker run --rm --privileged -v /:/host -e HOST=/host -e LOGDIR=${LOGDIR} -e CONFDIR=${CONFDIR} -e DATADIR=${DATADIR} --entrypoint /bin/sh -e NAME=NAME -e IMAGE=IMAGE IMAGE /root/atomic/install.sh"
+LABEL UNINSTALL="docker run --rm --privileged -v /:/host -e HOST=/host -e LOGDIR=${LOGDIR} -e CONFDIR=${CONFDIR} -e DATADIR=${DATADIR} --entrypoint /bin/sh -e NAME=NAME -e IMAGE=IMAGE IMAGE /root/atomic/uninstall.sh"
 
-COPY config.yml /etc/crontainer.yml
-COPY crontainer /usr/local/bin/crontainer
 
-RUN apk add --no-cache --update curl=7.57.0-r0
+COPY config.yml /etc/crontainer/crontainer.yml
+COPY bin/crontainer /usr/local/bin/crontainer
+COPY atomic /root/atomic
+
+RUN apk add --no-cache --update curl=7.58.0-r1
 
 ENTRYPOINT ["/usr/local/bin/crontainer"]
-CMD ["--config", "/etc/crontainer.yml"]
+CMD ["--config", "/etc/crontainer/crontainer.yml"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ test: vendor
 	go test -v ./...
 
 build:
-	go install ./...
+	go build -o bin/crontainer
+
+install:
+	go install
 
 run:
 	go run main.go --config examples/crontainer.yml

--- a/atomic/crontainer.service
+++ b/atomic/crontainer.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Crontainer Service
+After=Docker.service
+
+[Service]
+ExecStart=/usr/bin/docker run -v /etc/crontainer:/etc/crontainer:ro neckhair/crontainer NAME
+ExecStop=/usr/bin/docker stop NAME
+
+[Install]
+WantedBy=multi-user.target

--- a/atomic/install.sh
+++ b/atomic/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+
+chroot ${HOST} mkdir /etc/crontainer
+# Install systemd unit file for running container
+sed -e "s/NAME/${NAME}/g" /root/atomic/crontainer.service &> ${HOST}/etc/systemd/system/crontainer_${NAME}.service
+
+# Enabled systemd unit file
+chroot ${HOST} /usr/bin/systemctl daemon-reload
+chroot ${HOST} /usr/bin/systemctl enable /etc/systemd/system/crontainer_${NAME}.service

--- a/atomic/uninstall.sh
+++ b/atomic/uninstall.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# Disable and remove systemd unit file
+chroot ${HOST} /usr/bin/systemctl stop crontainer_${NAME}.service
+chroot ${HOST} /usr/bin/systemctl disable crontainer_${NAME}.service
+chroot ${HOST} rm -f /etc/systemd/system/crontainer_${NAME}.service


### PR DESCRIPTION
These changes allow the container to be used in atomic linux and installed via the `atomic` command.

Using `atomic install neckhair/crontainer` with this image will run `atomic/install.sh`, create a systemd file on the host machine, which will enabled the crontainer service on reboot.

`atomic uninstall neckhair/crontainer` will stop the service and remove the systemd file.

The systemd file expects that a volume `/etc/crontainer` is mounted in to the container with your config inside, hence the alteration to the default run command in the image.

I additionally had to change the image type to a glibc flavour alpine due to the usual goland alpine issues.